### PR TITLE
Add `SecurityControl: 'Ignore'` Tag to Trainer Demo Deploy Resources for MTT Managed Subscriptions

### DIFF
--- a/infra/eventhub.bicep
+++ b/infra/eventhub.bicep
@@ -3,6 +3,8 @@
 
 param location string = resourceGroup().location
 param name string
+param tags object = {}
+
 
 var abbrs = loadJsonContent('./abbreviations.json')
 var str_acc_name=  '${abbrs.storageStorageAccounts}${uniqueString(resourceGroup().id)}'
@@ -11,6 +13,7 @@ var str_acc_name=  '${abbrs.storageStorageAccounts}${uniqueString(resourceGroup(
 resource eventhub_resource 'Microsoft.EventHub/namespaces@2024-05-01-preview' = {
   name: name
   location: location
+  tags: tags
   sku: {
     name: 'Standard'
     tier: 'Standard'
@@ -39,6 +42,7 @@ resource eventhub_resource 'Microsoft.EventHub/namespaces@2024-05-01-preview' = 
 resource storageAccounts_resource 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: str_acc_name
   location: location
+  tags: tags
   sku: {
     name: 'Standard_LRS'
     tier: 'Standard'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,4 +1,4 @@
-targetScope = 'subscription'
+urityContrtargetScope = 'subscription'
 
 @minLength(1)
 @maxLength(64)
@@ -21,6 +21,7 @@ param principalId string
 //   tags: union(tags, { 'azd-service-name': <service name in azure.yaml> })
 var tags = {
   'azd-env-name': environmentName
+  SecurityControl: 'Ignore'
 }
 
 var abbrs = loadJsonContent('./abbreviations.json')

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,4 +1,4 @@
-urityContrtargetScope = 'subscription'
+targetScope = 'subscription'
 
 @minLength(1)
 @maxLength(64)
@@ -39,6 +39,7 @@ module eventhub 'eventhub.bicep' = {
   params: {
     name: !empty(ehServiceName) ? ehServiceName : '${abbrs.eventHubNamespaces}${resourceToken}'
     location: location
+    tags: tags
   }
 }
 


### PR DESCRIPTION


**Short answer:** We’re adding the `SecurityControl: 'Ignore'` tag to Trainer Demo Deploy projects so resources can run in **MTT managed subscriptions** without being blocked by default security policies.

---

## What Changed
We add the following tag during deployment:

```bicep
SecurityControl: 'Ignore' // Required for MTTs in managed subscriptions
````

> This tag is applied where resource tags are assembled created by the deployment. Then, I propagated the change to the underlying resources

***

## Why This Is Needed

*   **MTT managed subscriptions** enforce strict Azure Policy/Guardrails. Demo resources (short-lived, non-prod) can be flagged or blocked by controls intended for production workloads.
*   Adding `SecurityControl: 'Ignore'` allows training/demo resources to **bypass or quiet specific automated controls** designed for production, ensuring workshops and demos proceed without policy denials.
* Elements such as authenticating to storage accounts with keys is prohibited.

***

## Scope

*   Applies to all Trainer Demo Deploy repos using the shared tagging pattern.
*   Only affects **tags**; no changes to resource SKUs, regions, or identities.
*   Intended specifically for **training/demo** resources in **managed MTT subscriptions**.

***

## How It Works

*   During deployment, the tag object is merged into resource definitions.
*   `SecurityControl=Ignore` signals governance to allow these workloads under curated exemptions for training/demo environments.

***

## Testing Done

*   Verified tag appears on created resources.
*   Deployed into an MTT managed subscription to confirm policy no longer blocks templates.
*   Confirmed cleanup scripts still function as expected.

***

## Security & Compliance Notes

*   Tag adds **no privileges** and does not disable platform logging.
*   Still follow **data handling** and **cost controls** guidance.
*   **Do not** copy `SecurityControl=Ignore` into production or customer subscriptions.




## How to Validate

1.  Deploy to an MTT managed subscription.
2.  In Azure Portal, open the resource group → **Tags**: confirm
    *   `SecurityControl = Ignore`
3.  Confirm no policy denials block deployment.

***

## Checklist

*   [x] Tag applied at root of deployment so it flows to all resources
*   [x] Tested in MTT managed subscription
*   [x] No changes to SKUs/regions/quotas

***





